### PR TITLE
Refactor transfer worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: lint lint-ruff lint-pyright
+
+lint: lint-fix lint-pyright
+
+lint-ci: lint-ruff lint-pyright
+
+lint-ruff:
+	uv run ruff check .
+
+lint-pyright:
+	uv run pyright .
+
+# Run all linting in fix mode where possible
+lint-fix:
+	uv run ruff format .
+	uv run ruff check . --fix 

--- a/backup/__tests__/test_jump.py
+++ b/backup/__tests__/test_jump.py
@@ -1,27 +1,24 @@
 import pytest
 from pathlib import Path
-import os
-import shutil
 import tempfile
-import time
 from typing import Generator, Tuple
-import threading
 
-from backup.jump import TransferManager, FileTransferTask
+from backup.jump import TransferManager
+
 
 @pytest.fixture
 def test_file_structure() -> Generator[Tuple[Path, dict[str, bytes]], None, None]:
     """Create a temporary directory with test files and return the path and file contents.
-    
+
     Returns:
         Tuple of (temp_dir, file_contents) where file_contents is a dict of relative paths to content
     """
     with tempfile.TemporaryDirectory() as temp_dir:
         root_path = Path(temp_dir)
-        
+
         # Create a nested structure of test files with known content
         file_contents = {}
-        
+
         # Create some files in root
         for i in range(3):
             file_path = root_path / f"file_{i}.txt"
@@ -29,40 +26,48 @@ def test_file_structure() -> Generator[Tuple[Path, dict[str, bytes]], None, None
             content_bytes = content.encode()
             file_path.write_bytes(content_bytes)
             file_contents[f"file_{i}.txt"] = content_bytes
-        
+
         # Create nested directory structure
         nested_dir = root_path / "nested" / "subdirectory"
         nested_dir.mkdir(parents=True)
-        
+
         for i in range(2):
             file_path = nested_dir / f"nested_file_{i}.txt"
             content = f"Nested content for file {i}\n" * (i + 2)
             content_bytes = content.encode()
             file_path.write_bytes(content_bytes)
-            file_contents[str(Path("nested/subdirectory") / f"nested_file_{i}.txt")] = content_bytes
-            
+            file_contents[str(Path("nested/subdirectory") / f"nested_file_{i}.txt")] = (
+                content_bytes
+            )
+
         # Create a file with special characters
         special_file = root_path / "special_#$@!.txt"
         special_content = "Special content\n"
         special_content_bytes = special_content.encode()
         special_file.write_bytes(special_content_bytes)
         file_contents["special_#$@!.txt"] = special_content_bytes
-        
+
         yield root_path, file_contents
+
 
 @pytest.fixture
 def transfer_paths() -> Generator[Tuple[Path, Path, Path], None, None]:
     """Create temporary directories for source, jump, and destination.
-    
+
     Returns:
         Tuple of (source_dir, jump_dir, dest_dir)
     """
-    with tempfile.TemporaryDirectory() as source_dir, \
-         tempfile.TemporaryDirectory() as jump_dir, \
-         tempfile.TemporaryDirectory() as dest_dir:
+    with (
+        tempfile.TemporaryDirectory() as source_dir,
+        tempfile.TemporaryDirectory() as jump_dir,
+        tempfile.TemporaryDirectory() as dest_dir,
+    ):
         yield Path(source_dir), Path(jump_dir), Path(dest_dir)
 
-def setup_source_files(source_dir: Path, test_structure: Tuple[Path, dict[str, bytes]]) -> None:
+
+def setup_source_files(
+    source_dir: Path, test_structure: Tuple[Path, dict[str, bytes]]
+) -> None:
     """Helper to set up source directory with test files."""
     source_path, file_contents = test_structure
     for relative_path, content in file_contents.items():
@@ -70,96 +75,116 @@ def setup_source_files(source_dir: Path, test_structure: Tuple[Path, dict[str, b
         dest_file.parent.mkdir(parents=True, exist_ok=True)
         dest_file.write_bytes(content)
 
+
 def verify_files_match(dir_path: Path, file_contents: dict[str, bytes]) -> None:
     """Helper to verify files in directory match expected contents."""
     for relative_path, expected_content in file_contents.items():
         file_path = dir_path / relative_path
         assert file_path.exists(), f"File {relative_path} should exist"
-        assert file_path.read_bytes() == expected_content, f"Content mismatch for {relative_path}"
+        assert file_path.read_bytes() == expected_content, (
+            f"Content mismatch for {relative_path}"
+        )
 
-def test_scanner_generator(test_file_structure: Tuple[Path, dict[str, bytes]], transfer_paths: Tuple[Path, Path, Path]):
+
+def test_scanner_generator(
+    test_file_structure: Tuple[Path, dict[str, bytes]],
+    transfer_paths: Tuple[Path, Path, Path],
+):
     """Test that the file scanner generator works correctly."""
     source_dir, jump_path, dest_path = transfer_paths
     setup_source_files(source_dir, test_file_structure)
-    
+
     manager = TransferManager(
         source_path=source_dir,
         jump_path=jump_path,
         dest_path=dest_path,
     )
-    
+
     # Collect all tasks from generator
     tasks = list(manager.scan_files())
-    
+
     # Verify task count
     assert len(tasks) == len(test_file_structure[1])
-    
+
     # Verify all files are found
     found_paths = {str(task.relative_path) for task in tasks}
     expected_paths = set(test_file_structure[1].keys())
     assert found_paths == expected_paths
 
-def test_full_transfer_flow(test_file_structure: Tuple[Path, dict[str, bytes]], transfer_paths: Tuple[Path, Path, Path]):
+
+def test_full_transfer_flow(
+    test_file_structure: Tuple[Path, dict[str, bytes]],
+    transfer_paths: Tuple[Path, Path, Path],
+):
     """Test the complete transfer process from source to jump to destination."""
     source_dir, jump_path, dest_path = transfer_paths
     setup_source_files(source_dir, test_file_structure)
-    
+
     manager = TransferManager(
         source_path=source_dir,
         jump_path=jump_path,
         dest_path=dest_path,
     )
-    
+
     # Run the transfer
     manager.start_transfer()
-    
+
     # Verify files in destination
     verify_files_match(dest_path, test_file_structure[1])
-    
+
     # Verify jump drive is empty (all files should be cleaned up)
     jump_files = list(jump_path.glob("**/*"))
-    assert not any(f.is_file() for f in jump_files), "Jump drive should be empty after transfer"
-    
+    assert not any(f.is_file() for f in jump_files), (
+        "Jump drive should be empty after transfer"
+    )
+
     # Verify completion stats
     assert len(manager.jump_sync.completed_files) == len(test_file_structure[1])
     assert len(manager.dest_sync.completed_files) == len(test_file_structure[1])
     assert manager.jump_sync.transferred_bytes > 0
     assert manager.dest_sync.transferred_bytes > 0
 
-def test_skip_existing_files(test_file_structure: Tuple[Path, dict[str, bytes]], transfer_paths: Tuple[Path, Path, Path]):
+
+def test_skip_existing_files(
+    test_file_structure: Tuple[Path, dict[str, bytes]],
+    transfer_paths: Tuple[Path, Path, Path],
+):
     """Test that files are properly skipped when they exist at destination."""
     source_dir, jump_path, dest_path = transfer_paths
     setup_source_files(source_dir, test_file_structure)
-    
+
     # Create some files in destination first
     file_to_skip = next(iter(test_file_structure[1].items()))
     skip_path = dest_path / file_to_skip[0]
     skip_path.parent.mkdir(parents=True, exist_ok=True)
     skip_path.write_bytes(file_to_skip[1])
-    
+
     manager = TransferManager(
         source_path=source_dir,
         jump_path=jump_path,
         dest_path=dest_path,
     )
-    
+
     # Run the transfer
     manager.start_transfer()
-    
+
     # Verify skipped file wasn't overwritten
     assert skip_path.read_bytes() == file_to_skip[1]
     assert file_to_skip[0] in {str(p) for p in manager.skipped_files}
-    
+
     # Verify other files transferred
     for rel_path, content in test_file_structure[1].items():
         if rel_path != file_to_skip[0]:
             dest_file = dest_path / rel_path
             assert dest_file.exists()
             assert dest_file.read_bytes() == content
-    
+
     # Verify jump drive is empty
     jump_files = list(jump_path.glob("**/*"))
-    assert not any(f.is_file() for f in jump_files), "Jump drive should be empty after transfer"
+    assert not any(f.is_file() for f in jump_files), (
+        "Jump drive should be empty after transfer"
+    )
+
 
 def test_should_skip_patterns(transfer_paths: Tuple[Path, Path, Path]):
     """Test that should_skip correctly identifies files to skip."""
@@ -169,38 +194,46 @@ def test_should_skip_patterns(transfer_paths: Tuple[Path, Path, Path]):
         jump_path=jump_path,
         dest_path=dest_path,
     )
-    
+
     # Test .app bundle
     app_path = Path("Adobe Archive/Adobe Flash CS4/Adobe Flash CS4.app")
     assert manager.should_skip(app_path), "Should skip .app bundles"
-    
+
     # Test other common skip patterns
     assert manager.should_skip(Path(".DS_Store")), "Should skip .DS_Store"
     assert manager.should_skip(Path("Application.dmg")), "Should skip .dmg"
     assert manager.should_skip(Path("installer.pkg")), "Should skip .pkg"
-    
+
     # Test files that shouldn't be skipped
     assert not manager.should_skip(Path("normal.txt")), "Should not skip normal files"
     assert not manager.should_skip(Path("image.jpg")), "Should not skip images"
     assert not manager.should_skip(Path("document.pdf")), "Should not skip PDFs"
     assert not manager.should_skip(Path("data.json")), "Should not skip data files"
-    
+
     # Test paths with dots but not matching patterns
-    assert not manager.should_skip(Path("backup.dmg.txt")), "Should not skip if extension is part of name"
-    
+    assert not manager.should_skip(Path("backup.dmg.txt")), (
+        "Should not skip if extension is part of name"
+    )
+
     # Test paths with special characters
     assert not manager.should_skip(Path("file with spaces.txt")), "Should handle spaces"
-    assert not manager.should_skip(Path("special!@#$%^&.txt")), "Should handle special characters"
+    assert not manager.should_skip(Path("special!@#$%^&.txt")), (
+        "Should handle special characters"
+    )
 
-def test_discovered_files(test_file_structure: Tuple[Path, dict[str, bytes]], transfer_paths: Tuple[Path, Path, Path]):
+
+def test_discovered_files(
+    test_file_structure: Tuple[Path, dict[str, bytes]],
+    transfer_paths: Tuple[Path, Path, Path],
+):
     """Test that discovered files are properly loaded and processed."""
     source_dir, jump_path, dest_path = transfer_paths
     setup_source_files(source_dir, test_file_structure)
-    
+
     # Create a temporary discovered files path
     with tempfile.TemporaryDirectory() as dir:
         progress_path = Path(dir)
-        
+
         # First run - create the discovered files
         manager = TransferManager(
             source_path=source_dir,
@@ -208,20 +241,20 @@ def test_discovered_files(test_file_structure: Tuple[Path, dict[str, bytes]], tr
             dest_path=dest_path,
             progress_path=progress_path,
         )
-        
+
         # Run the transfer
         manager.start_transfer()
-        
+
         # Verify files were discovered and saved
         assert progress_path.exists()
         discovered_lines = manager.discovered_path.read_text().strip().split("\n")
         assert len(discovered_lines) == len(test_file_structure[1])
-        
+
         # Create a new file in the source directory
         new_file = source_dir / "new_file.txt"
         new_content = b"New file content"
         new_file.write_bytes(new_content)
-        
+
         # Second run - should load discovered files and find the new one
         manager = TransferManager(
             source_path=source_dir,
@@ -229,10 +262,9 @@ def test_discovered_files(test_file_structure: Tuple[Path, dict[str, bytes]], tr
             dest_path=dest_path,
             progress_path=progress_path,
         )
-        
+
         # Collect all tasks from generator to verify discovered + new files
         tasks = list(manager.scan_files())
-        
+
         # Since we've already scanned the files, we should only get one task
         assert len(tasks) == 1
-        

--- a/backup/__tests__/test_jump.py
+++ b/backup/__tests__/test_jump.py
@@ -121,10 +121,10 @@ def test_full_transfer_flow(test_file_structure: Tuple[Path, dict[str, bytes]], 
     assert not any(f.is_file() for f in jump_files), "Jump drive should be empty after transfer"
     
     # Verify completion stats
-    assert len(manager.completed_to_jump) == len(test_file_structure[1])
-    assert len(manager.completed_to_dest) == len(test_file_structure[1])
-    assert manager.transferred_to_jump > 0
-    assert manager.transferred_to_dest > 0
+    assert len(manager.jump_sync.completed_files) == len(test_file_structure[1])
+    assert len(manager.dest_sync.completed_files) == len(test_file_structure[1])
+    assert manager.jump_sync.transferred_bytes > 0
+    assert manager.dest_sync.transferred_bytes > 0
 
 def test_skip_existing_files(test_file_structure: Tuple[Path, dict[str, bytes]], transfer_paths: Tuple[Path, Path, Path]):
     """Test that files are properly skipped when they exist at destination."""

--- a/backup/backends/b2.py
+++ b/backup/backends/b2.py
@@ -25,16 +25,16 @@ class B2Backend(BaseBackend):
             service_name="s3",
             endpoint_url=endpoint,
             aws_access_key_id=key_id,
-            aws_secret_access_key=application_key
+            aws_secret_access_key=application_key,
         )
         self.b2_resource = resource(
-            service_name='s3',
+            service_name="s3",
             endpoint_url=endpoint,
             aws_access_key_id=key_id,
             aws_secret_access_key=application_key,
             config=Config(
-                signature_version='s3v4',
-            )
+                signature_version="s3v4",
+            ),
         )
         self.bucket_name = bucket_name
 

--- a/backup/cli.py
+++ b/backup/cli.py
@@ -1,19 +1,17 @@
-from click import command, group, option, confirm
+from click import group, option, confirm
 from backup.icloud import ICloudPhotosDownloader
 from backup.config import Settings, BackupBackend
 from dotenv import load_dotenv
 from backup.backends.local import LocalBackend
 from backup.backends.b2 import B2Backend
 from asyncio import run
-from click import group
 from backup.jump import start_jump_transfer
 from pathlib import Path
 from typing import Optional
 from rich import print as rprint
 
 # FIGLET font: Standard
-MAIN_LOGO = (    
-"""
+MAIN_LOGO = """
                     ___           ___           ___           ___           ___   
      _____         /  /\         /  /\         /__/|         /__/\         /  /\  
     /  /::\       /  /::\       /  /:/        |  |:|         \  \:\       /  /::\ 
@@ -26,11 +24,12 @@ MAIN_LOGO = (
     \  \::/       \  \:\        \  \::/       \  \:\        \  \::/       \  \:\  
      \__\/         \__\/         \__\/         \__\/         \__\/         \__\/  
 """
-)
+
 
 @group()
 def main():
     pass
+
 
 @main.command()
 def sync_icloud_photos():
@@ -60,12 +59,30 @@ def sync_icloud_photos():
     )
     run(icloud_photos.sync())
 
+
 @main.command()
 @option("--source", required=True, help="Path to source external drive")
 @option("--jump", required=True, help="Path to jump drive")
 @option("--dest", required=True, help="Path to destination external drive")
-@option("--progress-path", required=False, help="Path to save/load discovered files", default=None)
-def jump_transfer(source: str, jump: str, dest: str, progress_path: Optional[str] = None):
+@option(
+    "--progress-path",
+    required=False,
+    help="Path to save/load discovered files",
+    default=None,
+)
+@option(
+    "--max-queue-size",
+    required=False,
+    help="Maximum number of files to queue at once",
+    default=1000,
+)
+def jump_transfer(
+    source: str,
+    jump: str,
+    dest: str,
+    max_queue_size: int,
+    progress_path: Optional[str] = None,
+):
     """Transfer files from source to destination using a jump drive."""
     if progress_path:
         progress_path = Path(progress_path)
@@ -74,13 +91,20 @@ def jump_transfer(source: str, jump: str, dest: str, progress_path: Optional[str
 
         # Check if either file exists
         if discovered_file.exists() or transferred_file.exists():
-            rprint(f"[yellow]⚠️  Warning: Progress files already exist at {progress_path}[/yellow]")
-            rprint("[yellow]This could indicate an interrupted transfer or a different transfer using the same path.[/yellow]")
-            
-            if not confirm("Do you want to continue and append to the existing progress files?", default=False):
+            rprint(
+                f"[yellow]⚠️  Warning: Progress files already exist at {progress_path}[/yellow]"
+            )
+            rprint(
+                "[yellow]This could indicate an interrupted transfer or a different transfer using the same path.[/yellow]"
+            )
+
+            if not confirm(
+                "Do you want to continue and append to the existing progress files?",
+                default=False,
+            ):
                 rprint("[yellow]Transfer cancelled by user.[/yellow]")
                 return
-            
+
             rprint("[green]Continuing with existing progress files...[/green]")
-    
-    start_jump_transfer(source, jump, dest, progress_path)
+
+    start_jump_transfer(source, jump, dest, max_queue_size, progress_path)

--- a/backup/config.py
+++ b/backup/config.py
@@ -12,7 +12,7 @@ class BackupBackend(Enum):
 
 class Settings(BaseSettings):
     class Config:
-        env_nested_delimiter = '__'
+        env_nested_delimiter = "__"
 
     icloud_photos_username: str
 

--- a/backup/icloud.py
+++ b/backup/icloud.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from icloudpd import download, exif_datetime
 from icloudpd.authentication import TwoStepAuthRequiredError, authenticator
-from icloudpd.logger import setup_logger
 from icloudpd.paths import clean_filename
 from pyicloud_ipd.exceptions import PyiCloudAPIResponseError
 from tzlocal import get_localzone
@@ -36,7 +35,10 @@ class ICloudPhotosDownloader:
     https://github.com/icloud-photos-downloader/icloud_photos_downloader/blob/master/icloudpd/base.py#L288
 
     """
-    def __init__(self, username: str, password: str, backend: BaseBackend, concurrency: int = 10):
+
+    def __init__(
+        self, username: str, password: str, backend: BaseBackend, concurrency: int = 10
+    ):
         self.username = username
         self.password = password
         self.backend = backend
@@ -49,11 +51,14 @@ class ICloudPhotosDownloader:
         print("Done getting metadata, starting sync...")
 
         with Pool(self.concurrency) as pool:
-            for _ in tqdm(pool.imap_unordered(
-                partial(self.sync_photo, icloud),
-                self.iter_photos(photos),
-            ), total=len(photos)):
-                pass    
+            for _ in tqdm(
+                pool.imap_unordered(
+                    partial(self.sync_photo, icloud),
+                    self.iter_photos(photos),
+                ),
+                total=len(photos),
+            ):
+                pass
 
     def get_core_images(self, icloud, album_name: str):
         try:
@@ -77,7 +82,9 @@ class ICloudPhotosDownloader:
             try:
                 created_date = photo.created.astimezone(get_localzone())
             except (ValueError, OSError):
-                error(f"Could not convert photo created date to local timezone ({photo.created})")
+                error(
+                    f"Could not convert photo created date to local timezone ({photo.created})"
+                )
                 created_date = photo.created
 
             # The remote path should be prefixed with the date
@@ -86,7 +93,7 @@ class ICloudPhotosDownloader:
             yield PhotoContext(
                 photo=photo,
                 created_date=created_date,
-                remote_path=os.path.join(date_path, filename)
+                remote_path=os.path.join(date_path, filename),
             )
 
     def sync_photo(self, icloud, photo_payload: PhotoContext):
@@ -100,37 +107,35 @@ class ICloudPhotosDownloader:
 
             start_time = datetime.now()
             download_result = download.download_media(
-                icloud,
-                photo_payload.photo,
-                download_path,
-                PHOTO_SIZE
+                icloud, photo_payload.photo, download_path, PHOTO_SIZE
             )
             debug("Download Duration (ms)", datetime.now() - start_time)
 
-            self.inject_exif(photo_payload.photo, download_result, download_path, photo_payload.created_date)
+            self.inject_exif(
+                photo_payload.photo,
+                download_result,
+                download_path,
+                photo_payload.created_date,
+            )
 
             # Write this file to remote
             with open(download_path, "rb") as file:
                 self.backend.write_file(photo_payload.remote_path, file.read())
 
     def inject_exif(
-            self,
-            photo,
-            download_result,
-            download_path: str,
-            created_date: datetime,
-            set_exif_datetime: bool = True
-        ):
+        self,
+        photo,
+        download_result,
+        download_path: str,
+        created_date: datetime,
+        set_exif_datetime: bool = True,
+    ):
         if not download_result:
             return
 
         if (
             set_exif_datetime
-            and (
-                clean_filename(photo.filename)
-                .lower()
-                .endswith((".jpg", ".jpeg"))
-            )
+            and (clean_filename(photo.filename).lower().endswith((".jpg", ".jpeg")))
             and not exif_datetime.get_photo_exif(download_path)
         ):
             # %Y:%m:%d looks wrong, but it's the correct format

--- a/backup/jump.py
+++ b/backup/jump.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Literal, Dict, Set, Generator, Optional, Callable
+from typing import Dict, Set, Generator, Optional, Callable
 import shutil
 import os
 import threading
@@ -8,47 +8,45 @@ from dataclasses import dataclass, asdict
 import time
 from re import compile as re_compile
 import json
-from datetime import datetime
 
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    BarColumn,
-    TaskProgressColumn,
-    TimeRemainingColumn,
-    FileSizeColumn,
-)
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
 from rich import print as rprint
 from rich.panel import Panel
 
+
 @dataclass
 class FileTransferTask:
     """Represents a single file transfer task."""
+
     source: Path
     relative_path: Path
     size: int
 
+
 @dataclass
 class DiscoveredFile:
     """Represents a discovered file and its metadata."""
+
     relative_path: str
     size: int
     last_modified: float
     discovered_at: float
 
+
 @dataclass
 class AlreadyTransferredFile:
     """Represents a file that has already been transferred."""
+
     relative_path: str
     transferred_at: float
+
 
 @dataclass
 class DirectionalSync:
     """Handles file transfer between a source and destination path."""
+
     source_path: Path
     dest_path: Path
     queue: Queue[FileTransferTask]
@@ -63,25 +61,46 @@ class DirectionalSync:
     # Optional callbacks for post-transfer actions
     on_transfer_complete: Optional[Callable[[FileTransferTask], None]] = None
     on_cleanup: Optional[Callable[[Path], None]] = None
+    # Queue size limiting
+    max_queue_size: int = 100
+    queue_size_lock: threading.Lock = None
 
     def __post_init__(self):
         if self.completed_files is None:
             self.completed_files = set()
+        if self.queue_size_lock is None:
+            self.queue_size_lock = threading.Lock()
+
+    def wait_for_queue_space(self) -> None:
+        """Wait until there is space in the queue."""
+        while True:
+            with self.queue_size_lock:
+                if self.queue.qsize() < self.max_queue_size:
+                    return
+            time.sleep(0.1)
+
+    def put_task(self, task: FileTransferTask) -> None:
+        """Put a task in the queue, waiting if necessary."""
+        self.wait_for_queue_space()
+        self.queue.put(task)
 
     def transfer_worker(self, thread_id: int) -> None:
         """Worker function for file transfer threads."""
-        thread_name = f"{self.name}-{thread_id}"
-        
-        while not (self.stop_threads or 
-                  (self.scan_complete and self.queue.empty() and
-                   len(self.completed_files) == self.total_files)):
+        while not (
+            self.stop_threads
+            or (
+                self.scan_complete
+                and self.queue.empty()
+                and len(self.completed_files) == self.total_files
+            )
+        ):
             try:
                 task = self.queue.get(timeout=0.5)
             except Empty:
                 continue
 
             dest_path = self.dest_path / task.relative_path
-            
+
             # Skip if file exists at destination (double-check)
             if dest_path.exists():
                 self.queue.task_done()
@@ -90,7 +109,9 @@ class DirectionalSync:
             try:
                 dest_path.parent.mkdir(parents=True, exist_ok=True)
             except OSError as e:
-                rprint(f"[yellow]⚠️  Could not create parent directory for {dest_path}: {e}[/yellow]")
+                rprint(
+                    f"[yellow]⚠️  Could not create parent directory for {dest_path}: {e}[/yellow]"
+                )
                 self.queue.task_done()
                 continue
 
@@ -102,13 +123,15 @@ class DirectionalSync:
 
             try:
                 source_path = self.source_path / task.relative_path
-                
+
                 # Only proceed if source exists
                 if source_path.exists():
                     try:
                         shutil.copy2(source_path, dest_path)
-                        rprint(f"[green]✅ Transferred {task.relative_path} to {self.name}[/green]")
-                        
+                        rprint(
+                            f"[green]✅ Transferred {task.relative_path} to {self.name}[/green]"
+                        )
+
                         self.transferred_bytes += task.size
                         self.completed_files.add(task.relative_path)
 
@@ -121,7 +144,9 @@ class DirectionalSync:
                             self.on_cleanup(task.relative_path)
 
                     except Exception as e:
-                        rprint(f"[red]❌ Error copying {task.relative_path}: {str(e)}[/red]")
+                        rprint(
+                            f"[red]❌ Error copying {task.relative_path}: {str(e)}[/red]"
+                        )
                 else:
                     rprint(f"[yellow]⚠️  Source file not found: {source_path}[/yellow]")
             finally:
@@ -130,6 +155,7 @@ class DirectionalSync:
                     self.current_files.discard(task.relative_path)
 
             self.queue.task_done()
+
 
 # For now skip patterns just work at the filepath.name level
 SKIP_PATTERNS = [
@@ -143,11 +169,13 @@ SKIP_PATTERNS = [
     r"^NCSEXPER$",
     r"^Applications$",
     r"^Library$",
+    r"^Frameworks$",
 ]
+
 
 class TransferManager:
     """Manages parallel file transfers between source, jump drive, and destination."""
-    
+
     def __init__(
         self,
         source_path: Path,
@@ -155,45 +183,51 @@ class TransferManager:
         dest_path: Path,
         progress_path: Optional[Path] = None,
         num_threads: int = 2,
+        max_queue_size: int = 1000,
     ):
         if not source_path.exists():
             raise FileNotFoundError(f"Source path does not exist: {source_path}")
-            
+
         self.source_path = source_path
         self.jump_path = jump_path
         self.dest_path = dest_path
         self.progress_path = progress_path
-        self.discovered_path = progress_path / "discovered.jsonl" if progress_path else None
-        self.transferred_path = progress_path / "transferred.jsonl" if progress_path else None
+        self.discovered_path = (
+            progress_path / "discovered.jsonl" if progress_path else None
+        )
+        self.transferred_path = (
+            progress_path / "transferred.jsonl" if progress_path else None
+        )
         self.num_threads = num_threads
-        
+        self.max_queue_size = max_queue_size
+
         # Queues for each transfer stage
         self.to_jump_queue: Queue[FileTransferTask] = Queue()
         self.to_dest_queue: Queue[FileTransferTask] = Queue()
-        
+
         # Track progress
         self.total_size = 0
         self.skipped_size = 0
-        
+
         # Track completed files
         self.skipped_files: Set[Path] = set()
-        
+
         # Track current files being processed
         self.current_jump_files: Set[Path] = set()
         self.current_dest_files: Set[Path] = set()
-        
+
         # Control flags
         self.stop_threads = False
         self.scan_complete = False
         self.console = Console()
-        
+
         # Track total files for completion check
         self.total_files = 0
         self.files_found = 0
-        
+
         # Lock for updating current files
         self.current_files_lock = threading.Lock()
-        
+
         self.skip_regexes = [re_compile(pattern) for pattern in SKIP_PATTERNS]
 
         # Create sync managers
@@ -204,9 +238,10 @@ class TransferManager:
             current_files=self.current_jump_files,
             current_files_lock=self.current_files_lock,
             name="jump drive",
-            on_transfer_complete=lambda task: self.to_dest_queue.put(task)
+            on_transfer_complete=lambda task: self.dest_sync.put_task(task),
+            max_queue_size=max_queue_size,
         )
-        
+
         self.dest_sync = DirectionalSync(
             source_path=jump_path,
             dest_path=dest_path,
@@ -214,8 +249,11 @@ class TransferManager:
             current_files=self.current_dest_files,
             current_files_lock=self.current_files_lock,
             name="destination",
-            on_transfer_complete=lambda task: self.save_transferred_file(str(task.relative_path)),
-            on_cleanup=self.cleanup_jump_file
+            on_transfer_complete=lambda task: self.save_transferred_file(
+                str(task.relative_path)
+            ),
+            on_cleanup=self.cleanup_jump_file,
+            max_queue_size=max_queue_size,
         )
 
         # Load already transferred files
@@ -229,9 +267,15 @@ class TransferManager:
                         self.transferred_files[transferred.relative_path] = transferred
                     except (json.JSONDecodeError, KeyError):
                         continue
-            rprint(f"[blue]📚 Loaded {len(self.transferred_files)} previously transferred files[/blue]")
+            rprint(
+                f"[blue]📚 Loaded {len(self.transferred_files)} previously transferred files[/blue]"
+            )
 
-        rprint(Panel(f"[blue]Starting transfer process[/blue]\nSource: {source_path}\nJump Drive: {jump_path}\nDestination: {dest_path}"))
+        rprint(
+            Panel(
+                f"[blue]Starting transfer process[/blue]\nSource: {source_path}\nJump Drive: {jump_path}\nDestination: {dest_path}"
+            )
+        )
 
     def scan_files(self) -> Generator[FileTransferTask, None, None]:
         """Generator that yields file transfer tasks as they're discovered."""
@@ -246,23 +290,29 @@ class TransferManager:
             # Convert to Path if it's a string (from discovered files)
             if isinstance(file_path, str):
                 file_path = self.source_path / file_path
-                
+
             # Skip shortcuts, only copy underlying files
             try:
                 if file_path.is_symlink():
                     continue
             except OSError as e:
-                rprint(f"[dim yellow]⏩ Skipping {file_path} {e} (os error)[/dim yellow]")
+                rprint(
+                    f"[dim yellow]⏩ Skipping {file_path} {e} (os error)[/dim yellow]"
+                )
                 continue
 
             try:
                 relative_path = file_path.relative_to(self.source_path)
             except ValueError:
-                rprint(f"[dim yellow]⏩ Skipping {file_path} (not relative to source)[/dim yellow]")
+                rprint(
+                    f"[dim yellow]⏩ Skipping {file_path} (not relative to source)[/dim yellow]"
+                )
                 continue
-            
+
             if self.should_skip(file_path):
-                rprint(f"[dim yellow]⏩ Skipping {relative_path} (in skip list)[/dim yellow]")
+                rprint(
+                    f"[dim yellow]⏩ Skipping {relative_path} (in skip list)[/dim yellow]"
+                )
                 continue
 
             # Check if file has already been transferred - if so then we don't need any disk io
@@ -271,12 +321,16 @@ class TransferManager:
                 size = file_path.stat().st_size
                 self.skipped_size += size
                 self.skipped_files.add(relative_path)
-                rprint(f"[dim yellow]⏩ Skipping {relative_path} (already transferred)[/dim yellow]")
+                rprint(
+                    f"[dim yellow]⏩ Skipping {relative_path} (already transferred)[/dim yellow]"
+                )
                 continue
 
             # Check if file still exists
-            if not file_path.exists(): 
-                rprint(f"[dim yellow]⏩ Skipping {relative_path} (no longer exists)[/dim yellow]")
+            if not file_path.exists():
+                rprint(
+                    f"[dim yellow]⏩ Skipping {relative_path} (no longer exists)[/dim yellow]"
+                )
                 continue
 
             # Check if file already exists at final destination
@@ -284,11 +338,13 @@ class TransferManager:
             if dest_path.exists():
                 size = file_path.stat().st_size
                 self.skipped_size += size
-                self.skipped_files.add(relative_path)   
+                self.skipped_files.add(relative_path)
                 self.save_transferred_file(str(relative_path))
-                rprint(f"[dim yellow]⏩ Skipping {relative_path} (already at destination)[/dim yellow]")
+                rprint(
+                    f"[dim yellow]⏩ Skipping {relative_path} (already at destination)[/dim yellow]"
+                )
                 continue
-                
+
             size = file_path.stat().st_size
             self.total_size += size
             self.total_files += 1
@@ -297,18 +353,20 @@ class TransferManager:
             # Show status every second
             current_time = time.time()
             if current_time - last_status_time > 1:
-                rprint(f"[dim]📁 Found {self.files_found} files ({self.total_size / 1024 / 1024:.1f} MB total)[/dim]")
+                rprint(
+                    f"[dim]📁 Found {self.files_found} files ({self.total_size / 1024 / 1024:.1f} MB total)[/dim]"
+                )
                 last_status_time = current_time
-            
+
             yield FileTransferTask(
                 source=file_path,
                 relative_path=relative_path,
                 size=size,
             )
-    
+
     def iterate_known_paths(self) -> Generator[Path | str, None, None]:
         """Iterate over both discovered and newly found paths.
-        
+
         This is a two-phase generator:
         1. First yields all previously discovered paths from the discovery file
         2. Then walks the filesystem to find new paths, saving them as discovered
@@ -327,8 +385,10 @@ class TransferManager:
                         discovered_paths.add(discovered.relative_path)
                     except (json.JSONDecodeError, KeyError):
                         continue
-            
-            rprint(f"[blue]📚 Loaded {len(self.discovered_files)} previously discovered files[/blue]")
+
+            rprint(
+                f"[blue]📚 Loaded {len(self.discovered_files)} previously discovered files[/blue]"
+            )
 
             # First yield all discovered files that still exist
             for relative_path in discovered_paths:
@@ -339,7 +399,9 @@ class TransferManager:
         # We might need to create the parent directory if it doesn't exist
         if self.discovered_path:
             self.discovered_path.parent.mkdir(parents=True, exist_ok=True)
-            rprint(f"[blue]📚 Caching discovered files to {self.discovered_path}[/blue]")
+            rprint(
+                f"[blue]📚 Caching discovered files to {self.discovered_path}[/blue]"
+            )
 
         # Now walk the filesystem to find new paths
         for dirpath, dirnames, filenames in os.walk(self.source_path):
@@ -349,10 +411,12 @@ class TransferManager:
             # Check if the current directory should be skipped
             # If it should be skipped, remove all subdirs from dirnames to prevent descent
             if str(relative_path) != "." and self.should_skip(current_path):
-                rprint(f"[dim yellow]⏩ Skipping directory {relative_path} and its contents (in skip list)[/dim yellow]")
+                rprint(
+                    f"[dim yellow]⏩ Skipping directory {relative_path} and its contents (in skip list)[/dim yellow]"
+                )
                 dirnames.clear()  # This prevents os.walk from descending into this directory
                 continue
-        
+
             for filename in filenames:
                 file_path = current_path / filename
                 relative_str = str(file_path.relative_to(self.source_path))
@@ -374,22 +438,24 @@ class TransferManager:
         for task in self.scan_files():
             if self.stop_threads:
                 break
-            self.to_jump_queue.put(task)
-            
+            self.jump_sync.put_task(task)
+
         self.scan_complete = True
         self.jump_sync.scan_complete = True
         self.dest_sync.scan_complete = True
-        rprint(f"\n[green]✨ Scan complete![/green]")
-        rprint(Panel.fit(
-            "[green]Found {self.total_files} files to transfer[/green]\n"
-            f"Total size: {self.total_size / 1024 / 1024:.1f} MB\n"
-            f"Skipped {len(self.skipped_files)} existing files "
-            f"({self.skipped_size / 1024 / 1024:.1f} MB)"
-        ))
+        rprint("\n[green]✨ Scan complete![/green]")
+        rprint(
+            Panel.fit(
+                "[green]Found {self.total_files} files to transfer[/green]\n"
+                f"Total size: {self.total_size / 1024 / 1024:.1f} MB\n"
+                f"Skipped {len(self.skipped_files)} existing files "
+                f"({self.skipped_size / 1024 / 1024:.1f} MB)"
+            )
+        )
 
     def cleanup_jump_file(self, relative_path: Path) -> None:
         """Clean up a file from the jump drive after successful transfer.
-        
+
         Args:
             relative_path (Path): Relative path of the file to clean up
         """
@@ -406,7 +472,9 @@ class TransferManager:
                     # Directory not empty or already removed
                     break
         except Exception as e:
-            rprint(f"[yellow]⚠️  Could not remove file from jump drive: {relative_path} ({str(e)})[/yellow]")
+            rprint(
+                f"[yellow]⚠️  Could not remove file from jump drive: {relative_path} ({str(e)})[/yellow]"
+            )
 
     def create_progress_table(self) -> Table:
         """Create a progress table for display."""
@@ -417,34 +485,44 @@ class TransferManager:
         table.add_column("Queue Size")
         table.add_column("Space Used")
         table.add_column("Current Files")
-        
+
         # Calculate percentages and space usage
-        jump_percent = (self.jump_sync.transferred_bytes / self.total_size * 100) if self.total_size > 0 else 0
-        dest_percent = (self.dest_sync.transferred_bytes / self.total_size * 100) if self.total_size > 0 else 0
-        
+        jump_percent = (
+            (self.jump_sync.transferred_bytes / self.total_size * 100)
+            if self.total_size > 0
+            else 0
+        )
+        dest_percent = (
+            (self.dest_sync.transferred_bytes / self.total_size * 100)
+            if self.total_size > 0
+            else 0
+        )
+
         # Calculate actual space used on jump drive
         # We can use transferred_to_dest as the amount cleaned up since we delete files after successful transfer
-        jump_space_used = self.jump_sync.transferred_bytes - self.dest_sync.transferred_bytes
-        
+        jump_space_used = (
+            self.jump_sync.transferred_bytes - self.dest_sync.transferred_bytes
+        )
+
         # Format current files for display
         with self.current_files_lock:
             jump_files = ", ".join(str(p) for p in self.current_jump_files) or "None"
             dest_files = ", ".join(str(p) for p in self.current_dest_files) or "None"
-            
+
             # Truncate if too long
             max_length = 50
             if len(jump_files) > max_length:
                 jump_files = jump_files[:max_length] + "..."
             if len(dest_files) > max_length:
                 dest_files = dest_files[:max_length] + "..."
-        
+
         table.add_row(
             "[cyan]To Jump Drive[/cyan]",
             f"{jump_percent:.1f}% ({self.jump_sync.transferred_bytes / 1024 / 1024:.1f}/{self.total_size / 1024 / 1024:.1f} MB)",
             f"{len(self.jump_sync.completed_files)}/{self.total_files} files",
             f"Queue: {self.to_jump_queue.qsize()}",
             f"Using: {jump_space_used / 1024 / 1024:.1f} MB",
-            f"[dim]{jump_files}[/dim]"
+            f"[dim]{jump_files}[/dim]",
         )
         table.add_row(
             "[cyan]To Destination[/cyan]",
@@ -452,7 +530,7 @@ class TransferManager:
             f"{len(self.dest_sync.completed_files)}/{self.total_files} files",
             f"Queue: {self.to_dest_queue.qsize()}",
             "",
-            f"[dim]{dest_files}[/dim]"
+            f"[dim]{dest_files}[/dim]",
         )
         if self.skipped_files:
             table.add_row(
@@ -461,9 +539,9 @@ class TransferManager:
                 f"{len(self.skipped_files)} files",
                 "",
                 "",
-                ""
+                "",
             )
-        
+
         return table
 
     def start_transfer(self) -> None:
@@ -475,32 +553,30 @@ class TransferManager:
         # Update total files for both sync managers
         self.jump_sync.total_files = self.total_files
         self.dest_sync.total_files = self.total_files
-        
+
         # Start scanner thread
-        self.scanner_thread = threading.Thread(target=self.scanner_worker, name="Scanner")
+        self.scanner_thread = threading.Thread(
+            target=self.scanner_worker, name="Scanner"
+        )
         self.scanner_thread.daemon = True
         self.scanner_thread.start()
-        
+
         # Start transfer threads
         to_jump_threads = []
         to_dest_threads = []
-        
+
         for i in range(self.num_threads):
             # To jump drive threads
             thread = threading.Thread(
-                target=self.jump_sync.transfer_worker,
-                args=(i,),
-                name=f"JumpWorker-{i}"
+                target=self.jump_sync.transfer_worker, args=(i,), name=f"JumpWorker-{i}"
             )
             thread.daemon = True
             thread.start()
             to_jump_threads.append(thread)
-            
+
             # To destination threads
             thread = threading.Thread(
-                target=self.dest_sync.transfer_worker,
-                args=(i,),
-                name=f"DestWorker-{i}"
+                target=self.dest_sync.transfer_worker, args=(i,), name=f"DestWorker-{i}"
             )
             thread.daemon = True
             thread.start()
@@ -509,34 +585,43 @@ class TransferManager:
         try:
             # Display progress
             with Live(self.create_progress_table(), refresh_per_second=4) as live:
-                while any(thread.is_alive() for thread in [self.scanner_thread] + to_jump_threads + to_dest_threads):
+                while any(
+                    thread.is_alive()
+                    for thread in [self.scanner_thread]
+                    + to_jump_threads
+                    + to_dest_threads
+                ):
                     live.update(self.create_progress_table())
                     time.sleep(0.25)
-                    
+
                     # Extra completion check
-                    if (self.scan_complete and
-                        len(self.jump_sync.completed_files) == self.total_files and 
-                        len(self.dest_sync.completed_files) == self.total_files):
+                    if (
+                        self.scan_complete
+                        and len(self.jump_sync.completed_files) == self.total_files
+                        and len(self.dest_sync.completed_files) == self.total_files
+                    ):
                         break
-                    
+
         except KeyboardInterrupt:
             rprint("\n[yellow]⚠️  Transfer interrupted by user[/yellow]")
             self.stop_threads = True
             self.jump_sync.stop_threads = True
             self.dest_sync.stop_threads = True
             raise
-        
+
         finally:
             # Wait for threads to finish
             for thread in [self.scanner_thread] + to_jump_threads + to_dest_threads:
                 thread.join(timeout=1.0)
 
-        rprint(Panel.fit(
-            "[bold green]✨ Transfer complete![/bold green]\n"
-            f"Transferred: {self.total_files} files ({self.total_size / 1024 / 1024:.1f} MB)\n"
-            f"Skipped: {len(self.skipped_files)} files ({self.skipped_size / 1024 / 1024:.1f} MB)"
-        ))
-    
+        rprint(
+            Panel.fit(
+                "[bold green]✨ Transfer complete![/bold green]\n"
+                f"Transferred: {self.total_files} files ({self.total_size / 1024 / 1024:.1f} MB)\n"
+                f"Skipped: {len(self.skipped_files)} files ({self.skipped_size / 1024 / 1024:.1f} MB)"
+            )
+        )
+
     def should_skip(self, file_path: Path) -> bool:
         """Determine if a file should be skipped based on patterns."""
         # Right now we assume this list is small enough to iterate over for every filepath, if we start
@@ -585,14 +670,16 @@ class TransferManager:
             with open(self.transferred_path, "a") as f:
                 f.write(json.dumps(asdict(transferred)) + "\n")
 
+
 def start_jump_transfer(
     external_source: str,
     jump_drive: str,
     external_dest: str,
-    progress: Optional[str] = None,
+    max_queue_size: int,
+    progress: str | None = None,
 ) -> None:
     """Main function to handle the parallel file transfer process.
-    
+
     Args:
         external_source (str): Path to the source external drive
         jump_drive (str): Path to the jump drive
@@ -603,10 +690,10 @@ def start_jump_transfer(
     jump_path = Path(jump_drive)
     dest_path = Path(external_dest)
     progress_path = Path(progress) if progress else None
-    
+
     if not source_path.exists():
         raise FileNotFoundError(f"Source path does not exist: {source_path}")
-    
+
     manager = TransferManager(
         source_path=source_path,
         jump_path=jump_path,
@@ -614,7 +701,8 @@ def start_jump_transfer(
         progress_path=progress_path,
         # Use 1 thread per transfer direction for balance
         num_threads=1,
+        max_queue_size=max_queue_size,
     )
-    
+
     # Start parallel transfer
     manager.start_transfer()

--- a/backup/jump.py
+++ b/backup/jump.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Literal, Dict, Set, Generator, Optional
+from typing import Literal, Dict, Set, Generator, Optional, Callable
 import shutil
 import os
 import threading
@@ -46,6 +46,91 @@ class AlreadyTransferredFile:
     relative_path: str
     transferred_at: float
 
+@dataclass
+class DirectionalSync:
+    """Handles file transfer between a source and destination path."""
+    source_path: Path
+    dest_path: Path
+    queue: Queue[FileTransferTask]
+    current_files: Set[Path]
+    current_files_lock: threading.Lock
+    stop_threads: bool = False
+    scan_complete: bool = False
+    total_files: int = 0
+    completed_files: Set[Path] = None
+    transferred_bytes: int = 0
+    name: str = ""
+    # Optional callbacks for post-transfer actions
+    on_transfer_complete: Optional[Callable[[FileTransferTask], None]] = None
+    on_cleanup: Optional[Callable[[Path], None]] = None
+
+    def __post_init__(self):
+        if self.completed_files is None:
+            self.completed_files = set()
+
+    def transfer_worker(self, thread_id: int) -> None:
+        """Worker function for file transfer threads."""
+        thread_name = f"{self.name}-{thread_id}"
+        
+        while not (self.stop_threads or 
+                  (self.scan_complete and self.queue.empty() and
+                   len(self.completed_files) == self.total_files)):
+            try:
+                task = self.queue.get(timeout=0.5)
+            except Empty:
+                continue
+
+            dest_path = self.dest_path / task.relative_path
+            
+            # Skip if file exists at destination (double-check)
+            if dest_path.exists():
+                self.queue.task_done()
+                continue
+
+            try:
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                rprint(f"[yellow]⚠️  Could not create parent directory for {dest_path}: {e}[/yellow]")
+                self.queue.task_done()
+                continue
+
+            # Update current file being processed
+            with self.current_files_lock:
+                self.current_files.add(task.relative_path)
+
+            rprint(f"[dim]🔍 Transferring {task.relative_path} to {self.name}[/dim]")
+
+            try:
+                source_path = self.source_path / task.relative_path
+                
+                # Only proceed if source exists
+                if source_path.exists():
+                    try:
+                        shutil.copy2(source_path, dest_path)
+                        rprint(f"[green]✅ Transferred {task.relative_path} to {self.name}[/green]")
+                        
+                        self.transferred_bytes += task.size
+                        self.completed_files.add(task.relative_path)
+
+                        # Call post-transfer callback if provided
+                        if self.on_transfer_complete:
+                            self.on_transfer_complete(task)
+
+                        # Call cleanup callback if provided
+                        if self.on_cleanup:
+                            self.on_cleanup(task.relative_path)
+
+                    except Exception as e:
+                        rprint(f"[red]❌ Error copying {task.relative_path}: {str(e)}[/red]")
+                else:
+                    rprint(f"[yellow]⚠️  Source file not found: {source_path}[/yellow]")
+            finally:
+                # Remove from current files when done
+                with self.current_files_lock:
+                    self.current_files.discard(task.relative_path)
+
+            self.queue.task_done()
+
 # For now skip patterns just work at the filepath.name level
 SKIP_PATTERNS = [
     r"\.DS_Store$",
@@ -88,23 +173,14 @@ class TransferManager:
         
         # Track progress
         self.total_size = 0
-        self.transferred_to_jump = 0
-        self.transferred_to_dest = 0
         self.skipped_size = 0
         
         # Track completed files
-        self.completed_to_jump: Set[Path] = set()
-        self.completed_to_dest: Set[Path] = set()
         self.skipped_files: Set[Path] = set()
         
         # Track current files being processed
         self.current_jump_files: Set[Path] = set()
         self.current_dest_files: Set[Path] = set()
-        
-        # Threads
-        self.to_jump_threads: list[threading.Thread] = []
-        self.to_dest_threads: list[threading.Thread] = []
-        self.scanner_thread: Optional[threading.Thread] = None
         
         # Control flags
         self.stop_threads = False
@@ -119,6 +195,28 @@ class TransferManager:
         self.current_files_lock = threading.Lock()
         
         self.skip_regexes = [re_compile(pattern) for pattern in SKIP_PATTERNS]
+
+        # Create sync managers
+        self.jump_sync = DirectionalSync(
+            source_path=source_path,
+            dest_path=jump_path,
+            queue=self.to_jump_queue,
+            current_files=self.current_jump_files,
+            current_files_lock=self.current_files_lock,
+            name="jump drive",
+            on_transfer_complete=lambda task: self.to_dest_queue.put(task)
+        )
+        
+        self.dest_sync = DirectionalSync(
+            source_path=jump_path,
+            dest_path=dest_path,
+            queue=self.to_dest_queue,
+            current_files=self.current_dest_files,
+            current_files_lock=self.current_files_lock,
+            name="destination",
+            on_transfer_complete=lambda task: self.save_transferred_file(str(task.relative_path)),
+            on_cleanup=self.cleanup_jump_file
+        )
 
         # Load already transferred files
         self.transferred_files: Dict[str, AlreadyTransferredFile] = {}
@@ -279,6 +377,8 @@ class TransferManager:
             self.to_jump_queue.put(task)
             
         self.scan_complete = True
+        self.jump_sync.scan_complete = True
+        self.dest_sync.scan_complete = True
         rprint(f"\n[green]✨ Scan complete![/green]")
         rprint(Panel.fit(
             "[green]Found {self.total_files} files to transfer[/green]\n"
@@ -308,81 +408,6 @@ class TransferManager:
         except Exception as e:
             rprint(f"[yellow]⚠️  Could not remove file from jump drive: {relative_path} ({str(e)})[/yellow]")
 
-    def transfer_worker(
-        self,
-        queue: Queue[FileTransferTask],
-        base_dest: Path,
-        is_jump: bool,
-    ) -> None:
-        """Worker function for file transfer threads."""
-        stage = "jump drive" if is_jump else "destination"
-        thread_name = threading.current_thread().name
-        
-        while not (self.stop_threads or 
-                  (self.scan_complete and queue.empty() and
-                   ((is_jump and len(self.completed_to_jump) == self.total_files) or
-                    (not is_jump and len(self.completed_to_dest) == len(self.completed_to_jump))))):
-            try:
-                task = queue.get(timeout=0.5)
-            except Empty:
-                continue
-
-            dest_path = base_dest / task.relative_path
-            
-            # Skip if file exists at final destination (double-check)
-            if not is_jump and dest_path.exists():
-                queue.task_done()
-                continue
-            try:
-                dest_path.parent.mkdir(parents=True, exist_ok=True)
-            except OSError as e:
-                rprint(f"[yellow]⚠️  Could not create parent directory for {dest_path}: {e}[/yellow]")
-                queue.task_done()
-                continue
-
-            # Update current file being processed
-            with self.current_files_lock:
-                if is_jump:
-                    self.current_jump_files.add(task.relative_path)
-                else:
-                    self.current_dest_files.add(task.relative_path)
-            rprint(f"[dim]🔍 Transferring {task.relative_path} to {stage}[/dim]")
-
-            try:
-                # Determine source path based on stage
-                source_path = task.source if is_jump else (self.jump_path / task.relative_path)
-                
-                # Only proceed if source exists
-                if source_path.exists():
-                    try:
-                        shutil.copy2(source_path, dest_path)
-                        rprint(f"[green]✅ Transferred {task.relative_path} to {stage}[/green]")
-                        
-                        if is_jump:
-                            self.transferred_to_jump += task.size
-                            self.completed_to_jump.add(task.relative_path)
-                            # Add to destination queue once copied to jump
-                            self.to_dest_queue.put(task)
-                        else:
-                            self.transferred_to_dest += task.size
-                            self.completed_to_dest.add(task.relative_path)
-                            # Save as transferred and clean up from jump drive after successful transfer
-                            self.save_transferred_file(str(task.relative_path))
-                            self.cleanup_jump_file(task.relative_path)
-                    except Exception as e:
-                        rprint(f"[red]❌ Error copying {task.relative_path}: {str(e)}[/red]")
-                else:
-                    rprint(f"[yellow]⚠️  Source file not found: {source_path}[/yellow]")
-            finally:
-                # Remove from current files when done
-                with self.current_files_lock:
-                    if is_jump:
-                        self.current_jump_files.discard(task.relative_path)
-                    else:
-                        self.current_dest_files.discard(task.relative_path)
-
-            queue.task_done()
-
     def create_progress_table(self) -> Table:
         """Create a progress table for display."""
         table = Table()
@@ -394,13 +419,12 @@ class TransferManager:
         table.add_column("Current Files")
         
         # Calculate percentages and space usage
-        total_size_with_skipped = self.total_size + self.skipped_size
-        jump_percent = (self.transferred_to_jump / self.total_size * 100) if self.total_size > 0 else 0
-        dest_percent = (self.transferred_to_dest / self.total_size * 100) if self.total_size > 0 else 0
+        jump_percent = (self.jump_sync.transferred_bytes / self.total_size * 100) if self.total_size > 0 else 0
+        dest_percent = (self.dest_sync.transferred_bytes / self.total_size * 100) if self.total_size > 0 else 0
         
         # Calculate actual space used on jump drive
         # We can use transferred_to_dest as the amount cleaned up since we delete files after successful transfer
-        jump_space_used = self.transferred_to_jump - self.transferred_to_dest
+        jump_space_used = self.jump_sync.transferred_bytes - self.dest_sync.transferred_bytes
         
         # Format current files for display
         with self.current_files_lock:
@@ -416,16 +440,16 @@ class TransferManager:
         
         table.add_row(
             "[cyan]To Jump Drive[/cyan]",
-            f"{jump_percent:.1f}% ({self.transferred_to_jump / 1024 / 1024:.1f}/{self.total_size / 1024 / 1024:.1f} MB)",
-            f"{len(self.completed_to_jump)}/{self.total_files} files",
+            f"{jump_percent:.1f}% ({self.jump_sync.transferred_bytes / 1024 / 1024:.1f}/{self.total_size / 1024 / 1024:.1f} MB)",
+            f"{len(self.jump_sync.completed_files)}/{self.total_files} files",
             f"Queue: {self.to_jump_queue.qsize()}",
             f"Using: {jump_space_used / 1024 / 1024:.1f} MB",
             f"[dim]{jump_files}[/dim]"
         )
         table.add_row(
             "[cyan]To Destination[/cyan]",
-            f"{dest_percent:.1f}% ({self.transferred_to_dest / 1024 / 1024:.1f}/{self.total_size / 1024 / 1024:.1f} MB)",
-            f"{len(self.completed_to_dest)}/{self.total_files} files",
+            f"{dest_percent:.1f}% ({self.dest_sync.transferred_bytes / 1024 / 1024:.1f}/{self.total_size / 1024 / 1024:.1f} MB)",
+            f"{len(self.dest_sync.completed_files)}/{self.total_files} files",
             f"Queue: {self.to_dest_queue.qsize()}",
             "",
             f"[dim]{dest_files}[/dim]"
@@ -447,6 +471,10 @@ class TransferManager:
         # Create destination directories
         self.jump_path.mkdir(parents=True, exist_ok=True)
         self.dest_path.mkdir(parents=True, exist_ok=True)
+
+        # Update total files for both sync managers
+        self.jump_sync.total_files = self.total_files
+        self.dest_sync.total_files = self.total_files
         
         # Start scanner thread
         self.scanner_thread = threading.Thread(target=self.scanner_worker, name="Scanner")
@@ -454,48 +482,53 @@ class TransferManager:
         self.scanner_thread.start()
         
         # Start transfer threads
+        to_jump_threads = []
+        to_dest_threads = []
+        
         for i in range(self.num_threads):
             # To jump drive threads
             thread = threading.Thread(
-                target=self.transfer_worker,
-                args=(self.to_jump_queue, self.jump_path, True),
+                target=self.jump_sync.transfer_worker,
+                args=(i,),
                 name=f"JumpWorker-{i}"
             )
             thread.daemon = True
             thread.start()
-            self.to_jump_threads.append(thread)
+            to_jump_threads.append(thread)
             
             # To destination threads
             thread = threading.Thread(
-                target=self.transfer_worker,
-                args=(self.to_dest_queue, self.dest_path, False),
+                target=self.dest_sync.transfer_worker,
+                args=(i,),
                 name=f"DestWorker-{i}"
             )
             thread.daemon = True
             thread.start()
-            self.to_dest_threads.append(thread)
+            to_dest_threads.append(thread)
 
         try:
             # Display progress
             with Live(self.create_progress_table(), refresh_per_second=4) as live:
-                while any(thread.is_alive() for thread in [self.scanner_thread] + self.to_jump_threads + self.to_dest_threads):
+                while any(thread.is_alive() for thread in [self.scanner_thread] + to_jump_threads + to_dest_threads):
                     live.update(self.create_progress_table())
                     time.sleep(0.25)
                     
                     # Extra completion check
                     if (self.scan_complete and
-                        len(self.completed_to_jump) == self.total_files and 
-                        len(self.completed_to_dest) == self.total_files):
+                        len(self.jump_sync.completed_files) == self.total_files and 
+                        len(self.dest_sync.completed_files) == self.total_files):
                         break
                     
         except KeyboardInterrupt:
             rprint("\n[yellow]⚠️  Transfer interrupted by user[/yellow]")
             self.stop_threads = True
+            self.jump_sync.stop_threads = True
+            self.dest_sync.stop_threads = True
             raise
         
         finally:
             # Wait for threads to finish
-            for thread in [self.scanner_thread] + self.to_jump_threads + self.to_dest_threads:
+            for thread in [self.scanner_thread] + to_jump_threads + to_dest_threads:
                 thread.join(timeout=1.0)
 
         rprint(Panel.fit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ backup = "backup.cli:main"
 [dependency-groups]
 dev = [
     "isort==5.12.0",
+    "pyright>=1.1.393",
     "pytest==8.3.4",
+    "ruff>=0.9.5",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "isort" },
+    { name = "pyright" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -52,7 +54,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "isort", specifier = "==5.12.0" },
+    { name = "pyright", specifier = ">=1.1.393" },
     { name = "pytest", specifier = "==8.3.4" },
+    { name = "ruff", specifier = ">=0.9.5" },
 ]
 
 [[package]]
@@ -458,6 +462,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -540,6 +553,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.393"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/c1/aede6c74e664ab103673e4f1b7fd3d058fef32276be5c43572f4067d4a8e/pyright-1.1.393.tar.gz", hash = "sha256:aeeb7ff4e0364775ef416a80111613f91a05c8e01e58ecfefc370ca0db7aed9c", size = 3790430 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/47/f0dd0f8afce13d92e406421ecac6df0990daee84335fc36717678577d3e0/pyright-1.1.393-py3-none-any.whl", hash = "sha256:8320629bb7a44ca90944ba599390162bf59307f3d9fb6e27da3b7011b8c17ae5", size = 5646057 },
 ]
 
 [[package]]
@@ -638,6 +664,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.9.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/74/6c359f6b9ed85b88df6ef31febce18faeb852f6c9855651dfb1184a46845/ruff-0.9.5.tar.gz", hash = "sha256:11aecd7a633932875ab3cb05a484c99970b9d52606ce9ea912b690b02653d56c", size = 3634177 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/4b/82b7c9ac874e72b82b19fd7eab57d122e2df44d2478d90825854f9232d02/ruff-0.9.5-py3-none-linux_armv6l.whl", hash = "sha256:d466d2abc05f39018d53f681fa1c0ffe9570e6d73cde1b65d23bb557c846f442", size = 11681264 },
+    { url = "https://files.pythonhosted.org/packages/27/5c/f5ae0a9564e04108c132e1139d60491c0abc621397fe79a50b3dc0bd704b/ruff-0.9.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38840dbcef63948657fa7605ca363194d2fe8c26ce8f9ae12eee7f098c85ac8a", size = 11657554 },
+    { url = "https://files.pythonhosted.org/packages/2a/83/c6926fa3ccb97cdb3c438bb56a490b395770c750bf59f9bc1fe57ae88264/ruff-0.9.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d56ba06da53536b575fbd2b56517f6f95774ff7be0f62c80b9e67430391eeb36", size = 11088959 },
+    { url = "https://files.pythonhosted.org/packages/af/a7/42d1832b752fe969ffdbfcb1b4cb477cb271bed5835110fb0a16ef31ab81/ruff-0.9.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f7cb2a01da08244c50b20ccfaeb5972e4228c3c3a1989d3ece2bc4b1f996001", size = 11902041 },
+    { url = "https://files.pythonhosted.org/packages/53/cf/1fffa09fb518d646f560ccfba59f91b23c731e461d6a4dedd21a393a1ff1/ruff-0.9.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96d5c76358419bc63a671caac70c18732d4fd0341646ecd01641ddda5c39ca0b", size = 11421069 },
+    { url = "https://files.pythonhosted.org/packages/09/27/bb8f1b7304e2a9431f631ae7eadc35550fe0cf620a2a6a0fc4aa3d736f94/ruff-0.9.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:deb8304636ed394211f3a6d46c0e7d9535b016f53adaa8340139859b2359a070", size = 12625095 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/ab00bc9d3df35a5f1b64f5117458160a009f93ae5caf65894ebb63a1842d/ruff-0.9.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df455000bf59e62b3e8c7ba5ed88a4a2bc64896f900f311dc23ff2dc38156440", size = 13257797 },
+    { url = "https://files.pythonhosted.org/packages/88/81/c639a082ae6d8392bc52256058ec60f493c6a4d06d5505bccface3767e61/ruff-0.9.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de92170dfa50c32a2b8206a647949590e752aca8100a0f6b8cefa02ae29dce80", size = 12763793 },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/0a3d8f56d1e49af466dc770eeec5c125977ba9479af92e484b5b0251ce9c/ruff-0.9.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d28532d73b1f3f627ba88e1456f50748b37f3a345d2be76e4c653bec6c3e393", size = 14386234 },
+    { url = "https://files.pythonhosted.org/packages/04/70/e59c192a3ad476355e7f45fb3a87326f5219cc7c472e6b040c6c6595c8f0/ruff-0.9.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c746d7d1df64f31d90503ece5cc34d7007c06751a7a3bbeee10e5f2463d52d2", size = 12437505 },
+    { url = "https://files.pythonhosted.org/packages/55/4e/3abba60a259d79c391713e7a6ccabf7e2c96e5e0a19100bc4204f1a43a51/ruff-0.9.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11417521d6f2d121fda376f0d2169fb529976c544d653d1d6044f4c5562516ee", size = 11884799 },
+    { url = "https://files.pythonhosted.org/packages/a3/db/b0183a01a9f25b4efcae919c18fb41d32f985676c917008620ad692b9d5f/ruff-0.9.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b9d71c3879eb32de700f2f6fac3d46566f644a91d3130119a6378f9312a38e1", size = 11527411 },
+    { url = "https://files.pythonhosted.org/packages/0a/e4/3ebfcebca3dff1559a74c6becff76e0b64689cea02b7aab15b8b32ea245d/ruff-0.9.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2e36c61145e70febcb78483903c43444c6b9d40f6d2f800b5552fec6e4a7bb9a", size = 12078868 },
+    { url = "https://files.pythonhosted.org/packages/ec/b2/5ab808833e06c0a1b0d046a51c06ec5687b73c78b116e8d77687dc0cd515/ruff-0.9.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f71d09aeba026c922aa7aa19a08d7bd27c867aedb2f74285a2639644c1c12f5", size = 12524374 },
+    { url = "https://files.pythonhosted.org/packages/e0/51/1432afcc3b7aa6586c480142caae5323d59750925c3559688f2a9867343f/ruff-0.9.5-py3-none-win32.whl", hash = "sha256:134f958d52aa6fdec3b294b8ebe2320a950d10c041473c4316d2e7d7c2544723", size = 9853682 },
+    { url = "https://files.pythonhosted.org/packages/b7/ad/c7a900591bd152bb47fc4882a27654ea55c7973e6d5d6396298ad3fd6638/ruff-0.9.5-py3-none-win_amd64.whl", hash = "sha256:78cc6067f6d80b6745b67498fb84e87d32c6fc34992b52bffefbdae3442967d6", size = 10865744 },
+    { url = "https://files.pythonhosted.org/packages/75/d9/fde7610abd53c0c76b6af72fc679cb377b27c617ba704e25da834e0a0608/ruff-0.9.5-py3-none-win_arm64.whl", hash = "sha256:18a29f1a005bddb229e580795627d297dfa99f16b30c7039e73278cf6b5f9fa9", size = 10064595 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add cap on queue size growth, which limits how out of sync the two workers can get. This still isn't perfect and probably a cap on the overall jump storage would be better - but works for the current case.
- Add linting with ruff
- Refactor out our branching logic for different workers to a common src/dst sync class